### PR TITLE
logical2physicalで成功失敗を返すよう修正

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -14,7 +14,7 @@ func NewConvertor() *Convertor {
 	return &Convertor{make(map[string]struct{})}
 }
 
-func (c *Convertor) Logical2Physical(logicalName string, dict *Dictionary) string {
+func (c *Convertor) Logical2Physical(logicalName string, dict *Dictionary) (string, bool) {
 	var converted []string
 	r := []rune(logicalName)
 	// マッチしない語句が複数ある場合は、カンマ区切りでそれぞれの単語を出力する
@@ -56,8 +56,8 @@ func (c *Convertor) Logical2Physical(logicalName string, dict *Dictionary) strin
 		// 中途半端に物理名が設定されることを避けるために、変換に失敗した語句がある場合は物理名を設定しない
 		log.Printf("Fail to logical to physical [#%s]. remain [#%s]\n", logicalName, strings.Join(misses, ","))
 		c.missing[string(miss)] = struct{}{}
-		return logicalName
+		return "", false
 	}
 
-	return strings.Join(converted, "_")
+	return strings.Join(converted, "_"), true
 }

--- a/converter_test.go
+++ b/converter_test.go
@@ -8,16 +8,18 @@ func TestLogical2Physical(t *testing.T) {
 		dict        *Dictionary
 	}
 	tests := []struct {
-		name string
-		args args
-		want string
+		name    string
+		args    args
+		want    string
+		want_ok bool
 	}{
 		{
 			name: "マッチする",
 			args: args{logicalName: "あ", dict: &Dictionary{
 				{Key: "あ", Value: "a"},
 			}},
-			want: "a",
+			want:    "a",
+			want_ok: true,
 		},
 		{
 			name: "マッチする 複数",
@@ -25,7 +27,8 @@ func TestLogical2Physical(t *testing.T) {
 				{Key: "あ", Value: "a"},
 				{Key: "い", Value: "i"},
 			}},
-			want: "a_i",
+			want:    "a_i",
+			want_ok: true,
 		},
 		{
 			name: "マッチする 複数",
@@ -34,14 +37,16 @@ func TestLogical2Physical(t *testing.T) {
 				{Key: "あ", Value: "a"},
 				{Key: "い", Value: "i"},
 			}},
-			want: "love",
+			want:    "love",
+			want_ok: true,
 		},
 		{
 			name: "マッチしない",
 			args: args{logicalName: "あ", dict: &Dictionary{
 				{Key: "あい", Value: "love"},
 			}},
-			want: "あ",
+			want:    "",
+			want_ok: false,
 		},
 		{
 			name: "一部マッチ",
@@ -49,20 +54,26 @@ func TestLogical2Physical(t *testing.T) {
 				{Key: "い", Value: "i"},
 				{Key: "う", Value: "u"},
 			}},
-			want: "あいう",
+			want:    "",
+			want_ok: false,
 		},
 		{
 			name: "一部マッチ",
 			args: args{logicalName: "あいう", dict: &Dictionary{
 				{Key: "い", Value: "i"},
 			}},
-			want: "あいう",
+			want:    "",
+			want_ok: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewConvertor()
-			if got := c.Logical2Physical(tt.args.logicalName, tt.args.dict); got != tt.want {
+			got, ok := c.Logical2Physical(tt.args.logicalName, tt.args.dict)
+			if ok != tt.want_ok {
+				t.Errorf("got %v, want %v", ok, tt.want_ok)
+			}
+			if got != tt.want {
 				t.Errorf("Logical2Physical() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
## 課題
- 論物変換辞書に未定義の論理名（変換に失敗する項目）では、既存ERDにすでに何かの物理名があったとしても必ず論理名で上書きされてしまう仕様になっていた
- 変換に失敗した場合には、既存の物理名を上書きしない仕様に修正する

## 修正内容
- Logical2Physical()で、成功失敗を返し、失敗ならば呼び出し側で適切にハンドリングする形に修正しました


## テスト結果
```
>> go test
2022/07/08 10:20:42 Fail to logical to physical [#あ]. remain [#あ]
2022/07/08 10:20:42 Fail to logical to physical [#あいう]. remain [#あ]
2022/07/08 10:20:42 Fail to logical to physical [#あいう]. remain [#あ,う]
PASS
ok      github.com/future-architect/a5er-dictionary     0.089s
```

